### PR TITLE
Fix nogil_shared_ptr tests

### DIFF
--- a/tests/_test_nogil_holder.py.cpp
+++ b/tests/_test_nogil_holder.py.cpp
@@ -8,17 +8,40 @@ namespace py = pybind11;
 namespace pyext = Amulet::pybind11_extensions;
 
 class NoGILHolderTestClass {
+private:
+    bool& gil_held;
+
 public:
-    NoGILHolderTestClass() { }
-    ~NoGILHolderTestClass() {
-        if (PyGILState_Check()) {
-            throw std::runtime_error("GIL should not be held here.");
-        }
+    NoGILHolderTestClass(bool& gil_held)
+        : gil_held(gil_held)
+    {
+    }
+    ~NoGILHolderTestClass()
+    {
+        gil_held = PyGILState_Check();
+    }
+};
+
+class Bool {
+public:
+    bool value;
+
+    Bool(bool value)
+        : value(value)
+    {
+    }
+
+    operator bool()
+    {
+        return value;
     }
 };
 
 PYBIND11_MODULE(_test_nogil_holder, m)
 {
+    py::class_<Bool>(m, "Bool")
+        .def(py::init<bool>())
+        .def("__bool__", &Bool::operator bool);
     py::class_<NoGILHolderTestClass, pyext::nogil_shared_ptr<NoGILHolderTestClass>>(m, "NoGILHolderTestClass")
-        .def(py::init());
+        .def(py::init([](Bool& b) { return NoGILHolderTestClass(b.value); }));
 }

--- a/tests/test_nogil_holder.py
+++ b/tests/test_nogil_holder.py
@@ -4,11 +4,14 @@ from weakref import ref
 
 class NoGILHolderTestCase(unittest.TestCase):
     def test_nogil_holder(self) -> None:
-        from _test_nogil_holder import NoGILHolderTestClass
+        from _test_nogil_holder import Bool, NoGILHolderTestClass
 
-        cls = NoGILHolderTestClass()
+        b = Bool(True)
+        self.assertTrue(b)
+        cls = NoGILHolderTestClass(b)
         cls_ref = ref(cls)
         del cls
+        self.assertFalse(b)
         self.assertIsNone(cls_ref())
 
 


### PR DESCRIPTION
C++ cannot throw from the destructor